### PR TITLE
Fix "p=" public_key parser for archive

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -2,12 +2,16 @@ import { expect, test } from 'vitest'
 import { parseDkimTagList } from './utils';
 
 test('parseDkimTagList', () => {
-	expect(parseDkimTagList(' k=rsa;b=c; =foo   ; hello; b=duplicate_value_for_b; p=abcd12345;;;k2=v2')).toStrictEqual({
-		k: 'rsa',
-		p: 'abcd12345',
-		b: 'c',
-		k2: 'v2',
-	});
+	expect(
+    parseDkimTagList(
+      " k=rsa;b=c; =foo   ; hello; b=duplicate_value_for_b; p=DKIM1; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArkIVR9VjV+E605cxGymoapBUHX1ooeEFTJv9xCKgXQIgvAORT8BgzwGSYHMT/PFrVaHa3+6ESNKaSnPTIlVOWTddkOBBxlGz1+r/TEnCgD9JMD/0oHzQDj5v9+f+yMfcZo9Co1gH8Z23zvbI1ArO+YsBTAFuh4arIRVSzw+zTvrWZ/E9/sp71jaH4lrR+aLFhI2j3QN/jzugfBl/T+pHQlePJmlBGs9a7pkyMfQB1oYULdoxrxKoYob1GL7kdsMH5kqvvK8UyW2z1/3AhSoZAsFvjzuZUL182rhxZAAmP6n8u/o7Xugp7Ije+aEXXKBiZkqS9qNbDRjEkn2FaL/xkQIDAQAB;;;k2=v2"
+    )
+  ).toStrictEqual({
+    k: "rsa",
+    p: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArkIVR9VjV+E605cxGymoapBUHX1ooeEFTJv9xCKgXQIgvAORT8BgzwGSYHMT/PFrVaHa3+6ESNKaSnPTIlVOWTddkOBBxlGz1+r/TEnCgD9JMD/0oHzQDj5v9+f+yMfcZo9Co1gH8Z23zvbI1ArO+YsBTAFuh4arIRVSzw+zTvrWZ/E9/sp71jaH4lrR+aLFhI2j3QN/jzugfBl/T+pHQlePJmlBGs9a7pkyMfQB1oYULdoxrxKoYob1GL7kdsMH5kqvvK8UyW2z1/3AhSoZAsFvjzuZUL182rhxZAAmP6n8u/o7Xugp7Ije+aEXXKBiZkqS9qNbDRjEkn2FaL/xkQIDAQAB",
+    b: "c",
+    k2: "v2",
+  });
 
 	expect(parseDkimTagList('')).toStrictEqual({});
 


### PR DESCRIPTION
This PR fixes an edge case related to public key parsing. The parser now validates each public key and ignores any invalid ones. In the case of duplicate keys, the parser will use the last valid key encountered.