### PR TITLE
feat: lot of query optimisation

### DIFF
--- a/src/app/api/gcd_result_callback/route.ts
+++ b/src/app/api/gcd_result_callback/route.ts
@@ -128,18 +128,22 @@ async function storeCalculationResult(data: {
 }) {
 
   try {
+    // Normalize domain and selector to lowercase
+    const domain = data.metadata.domain.toLowerCase();
+    const selector = data.metadata.selector.toLowerCase();
+
     const domainSelectorPair = await prisma.domainSelectorPair.upsert({
       where: {
         id: await prisma.domainSelectorPair.findFirst({
           where: {
-            domain: data.metadata.domain,
-            selector: data.metadata.selector
+            domain: domain,
+            selector: selector
           }
         }).then(dsp => dsp?.id ?? -1)
       },
       create: {
-        domain: data.metadata.domain,
-        selector: data.metadata.selector,
+        domain: domain,
+        selector: selector,
         sourceIdentifier: 'api_auto',
         lastRecordUpdate: data.completedAt
       },
@@ -192,8 +196,8 @@ async function storeCalculationResult(data: {
     // Find the email signature entries 
     const emailSignatureA = await prisma.emailSignature.findFirst({
       where: {
-        domain: data.metadata.domain,
-        selector: data.metadata.selector,
+        domain: domain,
+        selector: selector,
         headerHash: data.metadata.headerHash1,
         dkimSignature: data.metadata.dkimSignature1
       }
@@ -201,8 +205,8 @@ async function storeCalculationResult(data: {
 
     const emailSignatureB = await prisma.emailSignature.findFirst({
       where: {
-        domain: data.metadata.domain,
-        selector: data.metadata.selector,
+        domain: domain,
+        selector: selector,
         headerHash: data.metadata.headerHash2,
         dkimSignature: data.metadata.dkimSignature2
       }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -24,7 +24,13 @@ const domainSelectorCache = new LRUCache<string, RecordWithSelector[]>({
 
 const createPrismaClient = () => {
 	const prismaUrl = new URL(process.env.POSTGRES_PRISMA_URL as string);
-	prismaUrl.searchParams.set('pool_timeout', '0');
+	
+	// Optimize connection pooling parameters
+	prismaUrl.searchParams.set('connection_limit', '20');        // Max connections
+	prismaUrl.searchParams.set('pool_timeout', '10');            // Pool acquire timeout (seconds)
+	prismaUrl.searchParams.set('connect_timeout', '10');         // Connection timeout
+	prismaUrl.searchParams.set('socket_timeout', '30');         // Query timeout
+	
 	return new PrismaClient({
 		datasources: {
 			db: {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -261,6 +261,7 @@ export function clearRecordsCache(domain?: string, selector?: string) {
     const cacheKey = generateCacheKey(domain, selector);
     domainSelectorCache.delete(cacheKey);
     domainCache.delete(domain);
+    dspIdCache.delete(cacheKey);
   } else if (domain) {
     domainCache.delete(domain);
     for (const key of domainSelectorCache.keys()) {
@@ -268,8 +269,14 @@ export function clearRecordsCache(domain?: string, selector?: string) {
         domainSelectorCache.delete(key);
       }
     }
+    for (const key of dspIdCache.keys()) {
+      if (key.startsWith(domain + ":")) {
+        dspIdCache.delete(key);
+      }
+    }
   } else {
     domainCache.clear();
     domainSelectorCache.clear();
+    dspIdCache.clear();
   }
 }

--- a/src/lib/utils_server.ts
+++ b/src/lib/utils_server.ts
@@ -33,14 +33,8 @@ export async function addDomainSelectorPair(domain: string, selector: string, so
 	// check if record exists
 	const dsp = await prisma.domainSelectorPair.findFirst({
 		where: {
-			domain: {
-				equals: domain,
-				mode: Prisma.QueryMode.insensitive,
-			},
-			selector: {
-				equals: selector,
-				mode: Prisma.QueryMode.insensitive
-			}
+			domain: domain,
+			selector: selector
 		}
 	});
 	if (dsp) {


### PR DESCRIPTION
### PR summary: end-to-end latency cuts for /api/key/domain

- In-flight request de-duplication
  - Single in-flight promise per `domain:selector` prevents thundering herd; 10 concurrent calls now share one DB hit.
  - Combined with caching and pool tuning, turned 200 calls into ~20 real DB operations.

- Input normalization
  - Lowercased `domain`/`selector` on write and read; removed case-insensitive mode.
  - Enables index use and avoids scan penalties.
  - Also double checked in database, we don't have any domain or selector with capital letter in it

- JOIN-free two-step lookup
  - Step 1: fetch `DomainSelectorPair.id` via `(domain, selector)`; Step 2: fetch `DkimRecord` via `domainSelectorPairId`.
  - Predictable, index-only access paths.

- DSP ID LRU cache
  - New `dspIdCache` (`domain:selector -> id`, TTL 1 day) skips Step 1 after first hit.
  - Invalidated alongside record caches in `clearRecordsCache`.

- Leaner payloads
  - Switched to `select` over `include`; only return `firstSeenAt`, `lastSeenAt`, `value` and minimal pair fields.
  - Cuts row size and serialization cost.

- Filter on server, not DB
  - Moved `value != 'p='` filtering into app code.
  - Avoids expensive text filtering on large column values at the DB layer.

- Cache improvements
  - 30-minute TTL LRU caches for domain and domain+selector, max size 1000.
  - Normalized cache keys and coordinated invalidation.

- Connection pool tuning
  - `connection_limit=20`, `pool_timeout=10s`, `connect_timeout=10s`, `socket_timeout=30s`.
  - Reduces pool acquisition timeouts and smooths bursts of 20–30 concurrent queries.
